### PR TITLE
Start relative file URLs with ./

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/ptgolden/lov-ns"
   },
   "exports": {
-    "import": "index.js",
-    "require": "index.cjs"
+    "import": "./index.js",
+    "require": "./index.cjs"
   },
   "keywords": [
     "rdf",
@@ -26,7 +26,7 @@
     "bump-version-after-update": "test \"Update data from LOV.\" = \"$(git log -1 --format='s')\" && (test \"$(git diff HEAD~1 HEAD --shortstat | grep deletion)\" && npm version major || npm version minor) || echo 'Last commit was not an update to the dataset.'"
   },
   "bin": {
-    "lov-ns": "get_ns.js"
+    "lov-ns": "./get_ns.js"
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
The Node docs [state](https://nodejs.org/api/packages.html#exports) that “All paths defined in the ‘exports’ must be relative file URLs starting with `./`” and recent versions of npm now enforce this. Not sure if the same applies to `bin` but [it seems to be recommended](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#bin).